### PR TITLE
Batch Tailscale port scans to prevent iOS connection drops

### DIFF
--- a/cli/scanner.js
+++ b/cli/scanner.js
@@ -58,7 +58,18 @@ function checkPort(host, port) {
   });
 }
 
-async function scanPorts(host, ports = SCAN_PORTS) {
+async function scanPorts(host, ports = SCAN_PORTS, { batchSize = 0 } = {}) {
+  if (batchSize > 0) {
+    const results = [];
+    for (let i = 0; i < ports.length; i += batchSize) {
+      const batch = ports.slice(i, i + batchSize);
+      const checks = await Promise.all(
+        batch.map(port => checkPort(host, port).then(open => ({ port, open })))
+      );
+      results.push(...checks);
+    }
+    return results.filter(c => c.open).map(c => c.port);
+  }
   const checks = await Promise.all(
     ports.map(port => checkPort(host, port).then(open => ({ port, open })))
   );
@@ -415,7 +426,8 @@ async function scanTailscale({ showAll = false } = {}) {
     if (!peer.online) return { ...peer, services: [] };
 
     // Scan using IP (fast), build URLs with MagicDNS name (valid HTTPS certs)
-    const openPorts = await scanPorts(peer.ip);
+    // Batch port scans for Tailscale peers to avoid flooding mobile WireGuard tunnels
+    const openPorts = await scanPorts(peer.ip, SCAN_PORTS, { batchSize: 5 });
     const isDarwin = isMacOS(peer.os);
     const services  = await Promise.all(openPorts.map(async (port) => {
       // Try MagicDNS name first (valid HTTPS certs); fall back to IP if DNS doesn't resolve

--- a/macos/Sources/Scanner.swift
+++ b/macos/Sources/Scanner.swift
@@ -279,7 +279,8 @@ enum Scanner {
                                       os: peer.os, online: false, services: [])
                     }
                     // Scan using IP (fast), but build URLs with MagicDNS name (for valid HTTPS certs)
-                    let openPorts = await tcpScanPorts(host: peer.ip)
+                    // Batch port scans to avoid flooding mobile WireGuard tunnels
+                    let openPorts = await tcpScanPorts(host: peer.ip, batchSize: 5)
                     let services  = await fetchServices(host: peer.dnsName, ports: openPorts, hints: [:], os: peer.os, showAll: showAll)
                     return Device(name: peer.name, ip: peer.dnsName, isLocal: false,
                                   os: peer.os, online: true, services: services)
@@ -296,9 +297,29 @@ enum Scanner {
 
     // MARK: - Port scanning
 
-    static func tcpScanPorts(host: String, ports portsToScan: [Int]? = nil) async -> [Int] {
-        await withTaskGroup(of: (Int, Bool).self) { group in
-            for port in portsToScan ?? ports {
+    static func tcpScanPorts(host: String, ports portsToScan: [Int]? = nil, batchSize: Int = 0) async -> [Int] {
+        let allPorts = portsToScan ?? ports
+        if batchSize > 0 {
+            var open: [Int] = []
+            for batchStart in stride(from: 0, to: allPorts.count, by: batchSize) {
+                let batchEnd = min(batchStart + batchSize, allPorts.count)
+                let batch = Array(allPorts[batchStart..<batchEnd])
+                let batchResults = await withTaskGroup(of: (Int, Bool).self) { group in
+                    for port in batch {
+                        group.addTask { (port, await tcpCheck(host: host, port: port)) }
+                    }
+                    var results: [Int] = []
+                    for await (port, isOpen) in group {
+                        if isOpen { results.append(port) }
+                    }
+                    return results
+                }
+                open.append(contentsOf: batchResults)
+            }
+            return open.sorted()
+        }
+        return await withTaskGroup(of: (Int, Bool).self) { group in
+            for port in allPorts {
                 group.addTask { (port, await tcpCheck(host: host, port: port)) }
             }
             var open: [Int] = []


### PR DESCRIPTION
## Summary
- Adds batched port scanning (5 at a time) for Tailscale peers in both the CLI (`scanner.js`) and macOS app (`Scanner.swift`)
- Prevents the concurrent 39-port TCP flood from overwhelming mobile WireGuard tunnels
- Local and gateway scans remain unbatched for speed since they don't go through WireGuard

## Test plan
- [ ] Run `web-finder` with an iOS device on Tailscale and verify the connection stays stable
- [ ] Verify scan still completes and finds all expected services

Fixes #2