### PR TITLE
Revert CLI/macOS port batching changes

### DIFF
--- a/cli/scanner.js
+++ b/cli/scanner.js
@@ -58,18 +58,7 @@ function checkPort(host, port) {
   });
 }
 
-async function scanPorts(host, ports = SCAN_PORTS, { batchSize = 0 } = {}) {
-  if (batchSize > 0) {
-    const results = [];
-    for (let i = 0; i < ports.length; i += batchSize) {
-      const batch = ports.slice(i, i + batchSize);
-      const checks = await Promise.all(
-        batch.map(port => checkPort(host, port).then(open => ({ port, open })))
-      );
-      results.push(...checks);
-    }
-    return results.filter(c => c.open).map(c => c.port);
-  }
+async function scanPorts(host, ports = SCAN_PORTS) {
   const checks = await Promise.all(
     ports.map(port => checkPort(host, port).then(open => ({ port, open })))
   );
@@ -426,8 +415,7 @@ async function scanTailscale({ showAll = false } = {}) {
     if (!peer.online) return { ...peer, services: [] };
 
     // Scan using IP (fast), build URLs with MagicDNS name (valid HTTPS certs)
-    // Batch port scans for Tailscale peers to avoid flooding mobile WireGuard tunnels
-    const openPorts = await scanPorts(peer.ip, SCAN_PORTS, { batchSize: 5 });
+    const openPorts = await scanPorts(peer.ip);
     const isDarwin = isMacOS(peer.os);
     const services  = await Promise.all(openPorts.map(async (port) => {
       // Try MagicDNS name first (valid HTTPS certs); fall back to IP if DNS doesn't resolve

--- a/macos/Sources/Scanner.swift
+++ b/macos/Sources/Scanner.swift
@@ -279,8 +279,7 @@ enum Scanner {
                                       os: peer.os, online: false, services: [])
                     }
                     // Scan using IP (fast), but build URLs with MagicDNS name (for valid HTTPS certs)
-                    // Batch port scans to avoid flooding mobile WireGuard tunnels
-                    let openPorts = await tcpScanPorts(host: peer.ip, batchSize: 5)
+                    let openPorts = await tcpScanPorts(host: peer.ip)
                     let services  = await fetchServices(host: peer.dnsName, ports: openPorts, hints: [:], os: peer.os, showAll: showAll)
                     return Device(name: peer.name, ip: peer.dnsName, isLocal: false,
                                   os: peer.os, online: true, services: services)
@@ -297,29 +296,9 @@ enum Scanner {
 
     // MARK: - Port scanning
 
-    static func tcpScanPorts(host: String, ports portsToScan: [Int]? = nil, batchSize: Int = 0) async -> [Int] {
-        let allPorts = portsToScan ?? ports
-        if batchSize > 0 {
-            var open: [Int] = []
-            for batchStart in stride(from: 0, to: allPorts.count, by: batchSize) {
-                let batchEnd = min(batchStart + batchSize, allPorts.count)
-                let batch = Array(allPorts[batchStart..<batchEnd])
-                let batchResults = await withTaskGroup(of: (Int, Bool).self) { group in
-                    for port in batch {
-                        group.addTask { (port, await tcpCheck(host: host, port: port)) }
-                    }
-                    var results: [Int] = []
-                    for await (port, isOpen) in group {
-                        if isOpen { results.append(port) }
-                    }
-                    return results
-                }
-                open.append(contentsOf: batchResults)
-            }
-            return open.sorted()
-        }
-        return await withTaskGroup(of: (Int, Bool).self) { group in
-            for port in allPorts {
+    static func tcpScanPorts(host: String, ports portsToScan: [Int]? = nil) async -> [Int] {
+        await withTaskGroup(of: (Int, Bool).self) { group in
+            for port in portsToScan ?? ports {
                 group.addTask { (port, await tcpCheck(host: host, port: port)) }
             }
             var open: [Int] = []


### PR DESCRIPTION
## Summary
Reverts the CLI and macOS scanner batching changes from PR #3. The connection issue was in the iOS app (not cleaning up connections on refresh), not in the CLI/macOS scanners. The CLI and macOS app scan correctly with full concurrency.

The actual fix is in PR #4 (iOS connection cleanup and scan cancellation).